### PR TITLE
exp(vendor-creator): add code for vendor create problem.

### DIFF
--- a/main.go
+++ b/main.go
@@ -1,0 +1,99 @@
+package main
+
+import (
+	"fmt"
+	"github.com/sonasingh46/exp/pkg"
+)
+
+// Background :
+
+// There are different vendors in market who creates some imaginary items
+// Every vendors again have different specialized machines to create thos items.
+
+// But there is a single supreme creator in the market and every customer go to the supreme creator and
+// the supreme creator finally creates the imaginary item as specified by customer create configuration
+// which decides the final vendor and creating machine of the vendor.
+
+// Vendor1 supports creation via  'machineX' and 'machineY'
+
+// Vendor2 supports creation via  'machineX' and 'machineY'
+
+/*
+
+pkg/vendor1.go contains vendor1 creation implementation via a functional approach of map
+
+pkg/vendor2.go contains vendor2 creation implementation via interface approach.
+
+I am trying to compare and contrast which one is a suitable and preferable approach with respect to
+following factors:
+
+1. Extensibility
+2. Maintainability
+3. Simplicity
+4. Idiomatic Go Patterns
+
+ */
+
+func main(){
+	// Test Code for vendor 1 creation
+	// Get create config of vendor1
+	vendor1CreateConfig:=pkg.NewVendor1Creator("machineX")
+
+	// Create the supreme creator by passing the create config
+	// This should run to finally create the item.
+	pcv1:=NewCreateConfig(vendor1CreateConfig)
+
+	pcv1.Run()
+
+	// Test Code for vendor 2 creation
+	// Get create config of vendor1
+	vendor2CreateConfig:=pkg.NewVendor2Creator("machineY")
+
+	// Create the supreme creator by passing the create config
+	// This should run to finally create the item.
+	pcv2:=NewCreateConfig(vendor2CreateConfig)
+
+	pcv2.Run()
+
+
+
+}
+
+// Following code from supreme creator side
+// that has an interface Create and this is implemented
+// by different vendors
+
+// CreateConfig knows how to create something.
+type CreateConfig struct {
+	creator Creator
+}
+
+// Creator interfaces abstract Create()
+type Creator interface {
+	Create()
+}
+
+// NewCreateConfig returns an instance of CreateConfig.
+func NewCreateConfig(p Creator) *CreateConfig {
+	return &CreateConfig{
+		creator:p,
+	}
+}
+// Run function is executed to create finally based on CreateConfig
+func(pc *CreateConfig)Run(){
+	fmt.Println("Creating...")
+	pc.creator.Create()
+}
+
+
+
+
+
+
+
+
+
+
+
+
+

--- a/pkg/vendor1.go
+++ b/pkg/vendor1.go
@@ -1,0 +1,49 @@
+package pkg
+
+import "fmt"
+
+// Vendor1Creator implements Create
+type Vendor1Creator struct {
+	value string
+}
+
+// NewVendor1Creator returns a Vendor1Creator instance.
+func NewVendor1Creator(machine string) *Vendor1Creator  {
+	return &Vendor1Creator{
+		// Change the values and run.
+		// Supported values : machineX. machineY
+		value:machine,
+	}
+}
+
+// Create is Vendor1Creator implementation.
+func (pc *Vendor1Creator) Create(/* Other possible args*/) {
+	fmt.Println("Creating via Vendor1")
+	f,ok:=createFuncMap[pc.value]
+	if !ok{
+		fmt.Println("Creation not supported via",pc.value)
+		return
+	}
+	f(pc)
+}
+
+// createFunc is a typed function for
+// vendor1 machine creators
+type createFunc func( *Vendor1Creator)
+
+// createFuncMap holds several
+// creator machines supported be vendor1
+var createFuncMap= map[string]createFunc{
+	"machineX":Vendor1CreatorViaMachineX,
+	"machineY":Vendor1CreatorViaMachineY,
+}
+
+// Vendor1CreatorViaMachineX creates via machineX
+func Vendor1CreatorViaMachineX(pc *Vendor1Creator)  {
+	fmt.Println("Creating via ",pc.value)
+}
+
+// Vendor1CreatorViaMachineX creates via machineY
+func Vendor1CreatorViaMachineY(pc *Vendor1Creator)  {
+	fmt.Println("Creating via ",pc.value)
+}

--- a/pkg/vendor2.go
+++ b/pkg/vendor2.go
@@ -1,0 +1,77 @@
+package pkg
+
+import (
+	"fmt"
+)
+
+
+// Vendor2Creator implements Create
+type Vendor2Creator struct {
+	value string
+}
+
+// NewVendor1Creator returns a Vendor1Creator instance.
+func NewVendor2Creator(machine string) *Vendor2Creator  {
+	return &Vendor2Creator{
+		// Change the values and run.
+		// Supported values : machineX. machineY
+		value:machine,
+	}
+}
+
+// Create is Vendor2Creator implementation.
+func (pc *Vendor2Creator) Create(/* Other possible args*/) {
+	fmt.Println("Creating via Vendor2")
+	v1m:=NewVendor1Machine(pc)
+	v1m.Create(pc)
+}
+
+// Machine abstracts Create at vendor layer
+type Machine interface {
+	Create(*Vendor2Creator)
+}
+
+// NewVendor1Machine returns a machine
+func NewVendor1Machine(pc *Vendor2Creator)Machine  {
+	if pc.value=="machineX"{
+		return &CreationViaX{}
+	}
+
+	if pc.value=="machineY"{
+		return &CreationViaX{}
+	}
+
+	return &CreationNoop{}
+}
+
+type CreationViaX struct {}
+
+type CreationViaY struct {}
+
+type CreationNoop struct {}
+
+func (pp *CreationViaX)Create(pc *Vendor2Creator)  {
+	fmt.Println("Provisioning via ",pc.value)
+}
+
+func (bp *CreationViaY)Create(pc *Vendor2Creator)  {
+	fmt.Println("Provisioning via ",pc.value)
+}
+
+func (noop *CreationNoop)Create(op *Vendor2Creator)  {
+	fmt.Printf("Provisioning via %s not supported\n",op.value)
+}
+
+
+
+
+
+
+
+
+
+
+
+
+
+


### PR DESCRIPTION
This PR adds code for vendor create problem. The background of the
problem is given in main.go

The intention of the problem is to basically identify when to use/not use
go interfaces.

Signed-off-by: Ashutosh Kumar <ashutosh.kumar@openebs.io>